### PR TITLE
Optimize filesystem open

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 `git-restore-mtime` sets the modified time of files and directories to the commit time from git. This is useful for build systems that cache actions based on modified time (Make, golang).
 
 This is inspired by a [python version](https://github.com/MestreLion/git-tools/blob/main/git-restore-mtime). This should theoretically be much faster, but is also slightly less accurate.
+
+## Known Issues
+
+- [worktree's are not supported](https://github.com/go-git/go-git/issues/483)

--- a/cmd/git-restore-mtime/main.go
+++ b/cmd/git-restore-mtime/main.go
@@ -2,24 +2,44 @@ package main
 
 import (
 	"os"
+	"runtime/pprof"
 
 	gitrestoremtime "github.com/gartnera/git-restore-mtime"
 	"github.com/spf13/cobra"
 )
 
 const (
-	maxDepthArg = "max-depth"
+	maxDepthArg   = "max-depth"
+	cpuProfileArg = "cpu-profile"
 )
 
 func init() {
 	flags := rootCmd.Flags()
 	flags.Int(maxDepthArg, 0, "maximum depth to traverse the commit history (default unlimited)")
+
+	persistentFlags := rootCmd.PersistentFlags()
+	persistentFlags.String(cpuProfileArg, "", "path to write pprof cpu profile")
 }
 
 var rootCmd = &cobra.Command{
 	Use:          "git-restore-mtime <path>",
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		cpuProfile, _ := cmd.Flags().GetString(cpuProfileArg)
+		if cpuProfile != "" {
+			f, err := os.Create(cpuProfile)
+			if err != nil {
+				return err
+			}
+			return pprof.StartCPUProfile(f)
+		}
+		return nil
+	},
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		pprof.StopCPUProfile()
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := []gitrestoremtime.ManagerOptionT{}
 		if maxDepth, _ := cmd.Flags().GetInt(maxDepthArg); maxDepth > 0 {


### PR DESCRIPTION
Reduce runtime by ~50% by opening the repo with some more optimized args. Related to #1.

Also add `--cpu-profile` argument.

After:

![image](https://github.com/gartnera/git-restore-mtime/assets/2747955/8c817804-0579-43f7-97f2-3131eb951e97)

[cpu.speedscope.json](https://github.com/user-attachments/files/16042321/cpu.speedscope.1.json)

